### PR TITLE
Fix Qt6 Widget Compilation Warnings on Windows & Complete the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ git clone --recursive https://github.com/stdware/qwindowkit
 cd qwindowkit
 
 cmake -B build -S . \
-  -Dqmsetup_DIR=<dir> \ # Optional: This can usually be "./qwindowkit/qmsetup"
+  -Dqmsetup_DIR=<dir> \ # Optional
   -DCMAKE_INSTALL_PREFIX=/path/to/install \
   -G "Ninja Multi-Config"
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ git clone --recursive https://github.com/stdware/qwindowkit
 cd qwindowkit
 
 cmake -B build -S . \
-  -Dqmsetup_DIR=<dir> \ # Optional
-  -DCMAKE_INSTALL_PREFIX=/path/install \
+  -Dqmsetup_DIR=<dir> \ # Optional: This can usually be "./qwindowkit/qmsetup"
+  -DCMAKE_INSTALL_PREFIX=/path/to/install \
   -G "Ninja Multi-Config"
 
 cmake --build build --target install --config Debug
@@ -107,12 +107,24 @@ project.
 #### CMake Project
 
 ```sh
-cmake -B build -DQWindowKit_DIR=/path/install/cmake/QWindowKit
+cmake -B build -DQWindowKit_DIR=/path/to/install/lib/cmake/QWindowKit
 ```
+Or, in the project settings of Qt Creator, locate the "CMake configuration"
+and then add a key-value pair in the "Current Configuration":
+
+|Key|Value|
+|:--|:--|
+|QWindowKit_DIR|/path/to/install/lib/cmake/QWindowKit|
 
 ```cmake
 find_package(QWindowKit REQUIRED)
+
+# Other configurations ...
+
+# Please note whether your project corresponds to 'Widgets' or 'Qt Quick'
+# Widget App
 target_link_libraries(widgets_app PUBLIC QWindowKit::Widgets)
+# Quick App
 target_link_libraries(quick_app PUBLIC QWindowKit::Quick)
 ```
 
@@ -139,7 +151,7 @@ TODO
 The following initialization should be done before any widget constructs.
 
 ```cpp
-#include <QWKQuick/qwkquickglobal.h>
+#include <QWKWidgets/widgetwindowagent.h>
 
 int main(int argc, char *argv[])
 {

--- a/src/widgets/widgetwindowagent_win.cpp
+++ b/src/widgets/widgetwindowagent_win.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2023-2024 Stdware Collections (https://www.github.com/stdware)
+// Copyright (C) 2023-2024 Stdware Collections (https://www.github.com/stdware)
 // Copyright (C) 2021-2023 wangwenx190 (Yuhang Zhao)
 // SPDX-License-Identifier: Apache-2.0
 
@@ -81,7 +81,6 @@ namespace QWK {
         }
 
     protected:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         bool sharedEventFilter(QObject *obj, QEvent *event) override {
             Q_UNUSED(obj)
 
@@ -96,35 +95,15 @@ namespace QWK {
                     // simply ignore it.
                     auto ee = static_cast<QExposeEvent *>(event);
                     auto window = widget->windowHandle();
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                     // 'const QRegion& QExposeEvent::region() const' is deprecated in Qt6
                     // Change the condition to check for QPaintEvent instead of QExposeEvent
-                    if (window->isExposed() && isNormalWindow() && event->type() == QEvent::Paint) {
-                        forwardEventToWindowAndDraw(window, event);
-                        return true;
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
-            return Windows10BorderHandler::sharedEventFilter(obj, event);
-        }
+                    if (window->isExposed() && isNormalWindow() && event->type() == QEvent::Paint)
 #else
-        bool sharedEventFilter(QObject *obj, QEvent *event) override {
-            Q_UNUSED(obj)
-
-            switch (event->type()) {
-                case QEvent::Expose: {
-                    // Qt will absolutely send a QExposeEvent or QResizeEvent to the QWindow when it
-                    // receives a WM_PAINT message. When the control flow enters the expose handler,
-                    // Qt must have already called BeginPaint() and it's the best time for us to
-                    // draw the top border.
-
-                    // Since a QExposeEvent will be sent immediately after the QResizeEvent, we can
-                    // simply ignore it.
-                    auto ee = static_cast<QExposeEvent *>(event);
-                    auto window = widget->windowHandle();
-                    if (window->isExposed() && isNormalWindow() && !ee->region().isNull()) {
+                    if (window->isExposed() && isNormalWindow() && !ee->region().isNull())
+#endif
+                    {
                         forwardEventToWindowAndDraw(window, event);
                         return true;
                     }
@@ -135,7 +114,6 @@ namespace QWK {
             }
             return Windows10BorderHandler::sharedEventFilter(obj, event);
         }
-#endif
 
         bool eventFilter(QObject *obj, QEvent *event) override {
             Q_UNUSED(obj)


### PR DESCRIPTION
# 修复 Qt6 Widget 的编译警告
请参考 https://doc.qt.io/qt-6.5/qexposeevent.html
'const QRegion &QExposeEvent::region() const'
This function is deprecated since 6.0. We strongly advise against using it in new code. Use QPaintEvent instead.
Returns the window area that has been exposed. The region is given in local coordinates.

这个函数已经在 Qt6.0 中被废弃，所以我增加了版本判断并修复了在 Qt6 中的问题。

# README 完善
1. 在 Import - CMake Project 部分添加了更加详细的说明，帮助使用者理解。
2. 改了一处可能的笔误：
![image](https://github.com/stdware/qwindowkit/assets/86941555/875262db-5570-4007-a685-034cf032d082)

