### PR TITLE
Fixes find_dependency() syntax in QWindowKitConfig.cmake

### DIFF
--- a/src/QWindowKitConfig.cmake.in
+++ b/src/QWindowKitConfig.cmake.in
@@ -6,13 +6,13 @@ find_dependency(QT NAMES Qt6 Qt5 COMPONENTS Core Gui REQUIRED)
 find_dependency(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui REQUIRED)
 
 if ("Widgets" IN_LIST QWindowKit_FIND_COMPONENTS)
-    find_dependency(QT NAMES Qt6 Qt5 Widgets REQUIRED)
-    find_dependency(Qt${QT_VERSION_MAJOR} Widgets REQUIRED)
+    find_dependency(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+    find_dependency(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 endif()
 
 if ("Quick" IN_LIST QWindowKit_FIND_COMPONENTS)
-    find_dependency(QT NAMES Qt6 Qt5 Quick REQUIRED)
-    find_dependency(Qt${QT_VERSION_MAJOR} Quick REQUIRED)
+    find_dependency(QT NAMES Qt6 Qt5 COMPONENTS Quick REQUIRED)
+    find_dependency(Qt${QT_VERSION_MAJOR} COMPONENTS Quick REQUIRED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/QWindowKitTargets.cmake")


### PR DESCRIPTION
I recently integrated this into a project I am working on and found that I needed to edit the QWindowKitConfig.cmake file after installing to fix this syntax issue, otherwise I wasn't able to compile my project.