### PR TITLE
quickwindowagent.h: Remove const for HitTestVisible API.

### DIFF
--- a/src/quick/quickwindowagent.cpp
+++ b/src/quick/quickwindowagent.cpp
@@ -82,12 +82,19 @@ namespace QWK {
         Q_EMIT systemButtonChanged(button, item);
     }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    bool QuickWindowAgent::isHitTestVisible(QQuickItem *item) const {
+#else
     bool QuickWindowAgent::isHitTestVisible(const QQuickItem *item) const {
+#endif
         Q_D(const QuickWindowAgent);
         return d->context->isHitTestVisible(item);
     }
-
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    void QuickWindowAgent::setHitTestVisible(QQuickItem *item, bool visible) {
+#else
     void QuickWindowAgent::setHitTestVisible(const QQuickItem *item, bool visible) {
+#endif
         Q_D(QuickWindowAgent);
         d->context->setHitTestVisible(item, visible);
     }

--- a/src/quick/quickwindowagent.h
+++ b/src/quick/quickwindowagent.h
@@ -31,8 +31,13 @@ namespace QWK {
         Q_INVOKABLE QQuickItem *systemButton(SystemButton button) const;
         Q_INVOKABLE void setSystemButton(SystemButton button, QQuickItem *item);
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+        Q_INVOKABLE bool isHitTestVisible(QQuickItem *item) const;
+        Q_INVOKABLE void setHitTestVisible(QQuickItem *item, bool visible = true);
+#else
         Q_INVOKABLE bool isHitTestVisible(const QQuickItem *item) const;
         Q_INVOKABLE void setHitTestVisible(const QQuickItem *item, bool visible = true);
+#endif
 
 #ifdef Q_OS_MAC
         // The system button area APIs are experimental, very likely to change in the future.


### PR DESCRIPTION
Solving QML engine overload problem( #87 ) in Qt5