### PR TITLE
QWKCore/cocoawindowcontext: Use typeId() instead of type() in Qt 6.0+.

### DIFF
--- a/src/core/contexts/cocoawindowcontext.mm
+++ b/src/core/contexts/cocoawindowcontext.mm
@@ -745,7 +745,11 @@ namespace QWK {
         Q_ASSERT(m_windowId);
 
         if (key == QStringLiteral("no-system-buttons")) {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
             if (attribute.type() != QVariant::Bool)
+#else
+            if (attribute.typeId() != QMetaType::Type::Bool)
+#endif
                 return false;
             ensureWindowProxy(m_windowId)->setSystemButtonVisible(!attribute.toBool());
             return true;
@@ -753,14 +757,22 @@ namespace QWK {
 
         if (key == QStringLiteral("blur-effect")) {
             auto mode = NSWindowProxy::BlurMode::None;
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
             if (attribute.type() == QVariant::Bool) {
+#else
+            if (attribute.typeId() == QMetaType::Type::Bool) {
+#endif
                 if (attribute.toBool()) {
                     NSString *osxMode =
                         [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
                     mode = [osxMode isEqualToString:@"Dark"] ? NSWindowProxy::BlurMode::Dark
                                                              : NSWindowProxy::BlurMode::Light;
                 }
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
             } else if (attribute.type() == QVariant::String) {
+#else
+            } else if (attribute.typeId() == QMetaType::Type::QString) {
+#endif
                 auto value = attribute.toString();
                 if (value == QStringLiteral("dark")) {
                     mode = NSWindowProxy::BlurMode::Dark;


### PR DESCRIPTION
用typeId()代替type()来消除在Qt 6.0+上出现的编译警告，因为type()已经被标记为弃用。

相关编译警告如下：
```shell
warning: 'type' is deprecated: Use typeId() or metaType(). [-Wdeprecated-declarations]
  748 |             if (attribute.type() != QVariant::Bool)
```