### PR TITLE
Fix bugs in title bar double-click handling on macOS

### DIFF
--- a/src/core/contexts/cocoawindowcontext.mm
+++ b/src/core/contexts/cocoawindowcontext.mm
@@ -665,8 +665,7 @@ namespace QWK {
                 if (me->button() == Qt::LeftButton && inTitleBar && !m_context->isHostSizeFixed()) {
                     Qt::WindowFlags windowFlags = delegate->getWindowFlags(host);
                     Qt::WindowStates windowState = delegate->getWindowState(host);
-                    if ((windowFlags & Qt::WindowMaximizeButtonHint) &&
-                        !(windowState & Qt::WindowFullScreen)) {
+                    if (!(windowState & Qt::WindowFullScreen)) {
                         if (windowState & Qt::WindowMaximized) {
                             delegate->setWindowState(host, windowState & ~Qt::WindowMaximized);
                         } else {


### PR DESCRIPTION
The testing of `Qt::WindowMaximizeButtonHint` flag is removed.

Since there is no "maximize button" in macOS windows at all, the previous behavior would reject all double-click events.