### PR TITLE
Fix X11 context menu pointer grab causing UI freeze

### DIFF
--- a/src/core/contexts/linuxx11context.cpp
+++ b/src/core/contexts/linuxx11context.cpp
@@ -182,6 +182,7 @@ namespace QWK {
             ev.xclient.data.l[2] = root_y;
 
             Window root = DefaultRootWindow(display);
+            api.XUngrabPointer(display, 0L);
             api.XSendEvent(display, root, False, SubstructureRedirectMask | SubstructureNotifyMask,
                            &ev);
             api.XFlush(display);

--- a/src/core/qwindowkit_linux.cpp
+++ b/src/core/qwindowkit_linux.cpp
@@ -74,6 +74,8 @@ namespace QWK {
                     api.XSendEvent =
                         reinterpret_cast<LinuxX11API::XSendEventFn>(x11lib.resolve("XSendEvent"));
                     api.XFlush = reinterpret_cast<LinuxX11API::XFlushFn>(x11lib.resolve("XFlush"));
+                    api.XUngrabPointer = reinterpret_cast<LinuxX11API::XUngrabPointerFn>(
+                        x11lib.resolve("XUngrabPointer"));
                 }
             }
             guard = false;

--- a/src/core/qwindowkit_linux.h
+++ b/src/core/qwindowkit_linux.h
@@ -41,13 +41,15 @@ namespace QWK {
             using XInternAtomFn = Atom (*)(Display *, const char *, Bool);
             using XSendEventFn = int (*)(Display *, Window, Bool, long, XEvent *);
             using XFlushFn = int (*)(Display *);
+            using XUngrabPointerFn = int (*)(Display *, unsigned long);
 
             XInternAtomFn XInternAtom = nullptr;
             XSendEventFn XSendEvent = nullptr;
             XFlushFn XFlush = nullptr;
+            XUngrabPointerFn XUngrabPointer = nullptr;
 
             inline bool isValid() const {
-                return XInternAtom && XSendEvent && XFlush;
+                return XInternAtom && XSendEvent && XFlush && XUngrabPointer;
             }
         };
 


### PR DESCRIPTION
Found during Jami testing with Qt 6.10.1/qwindowkit on X11: right-clicking on the title bar trapped the mouse event, freezing the main window. Please advise.