### PR TITLE
Add dwm-border-color attribute using DWMWA_BORDER_COLOR (Win11) + exa…

### DIFF
--- a/examples/mainwindow/mainwindow.cpp
+++ b/examples/mainwindow/mainwindow.cpp
@@ -13,6 +13,7 @@
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QStyle>
 #include <QtWidgets/QPushButton>
+#include <QtWidgets/QColorDialog>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #  include <QtGui/QActionGroup>
 #else
@@ -209,6 +210,17 @@ void MainWindow::installWindowAgent() {
                     style()->polish(this);
                 });
 
+        auto borderColorAction = new QAction(tr("Border color"), menuBar);
+        borderColorAction->setData(QStringLiteral("dwm-border-color"));
+        borderColorAction->setCheckable(false);
+        connect(borderColorAction, &QAction::triggered, this, [this, borderColorAction]() {
+            QColor color = QColorDialog::getColor(Qt::black, this, tr("Select window border color"));
+            if (color.isValid()) {
+                const QString data = borderColorAction->data().toString();
+                windowAgent->setWindowAttribute(data, color);
+                style()->polish(this);
+            }
+        });
 #elif defined(Q_OS_MAC)
         // Set whether to use system buttons (close/minimize/zoom)
         // - true:  Hide system buttons (use custom UI controls)
@@ -268,6 +280,8 @@ void MainWindow::installWindowAgent() {
         settings->addAction(acrylicAction);
         settings->addAction(micaAction);
         settings->addAction(micaAltAction);
+        settings->addSeparator();
+        settings->addAction(borderColorAction);
 #elif defined(Q_OS_MAC)
         settings->addAction(darkBlurAction);
         settings->addAction(lightBlurAction);

--- a/src/core/contexts/win32windowcontext.cpp
+++ b/src/core/contexts/win32windowcontext.cpp
@@ -1193,6 +1193,20 @@ namespace QWK {
             effectBugWorkaround();
             return true;
         }
+        
+        if (key == QStringLiteral("dwm-border-color")) {
+            if (!isWin11OrGreater()) {
+                return false;
+            }
+            if (!attribute.canConvert<QColor>()) {
+                return false;
+            }
+
+            QColor color = attribute.value<QColor>();
+            COLORREF colorRef = RGB(color.red(), color.green(), color.blue());
+            apis.pDwmSetWindowAttribute(hwnd, _DWMWA_BORDER_COLOR, &colorRef, sizeof(colorRef));
+            return true;
+        }
         return false;
     }
 

--- a/src/core/shared/qwkwindowsextra_p.h
+++ b/src/core/shared/qwkwindowsextra_p.h
@@ -78,6 +78,9 @@ namespace QWK {
         // [set] WINDOW_CORNER_PREFERENCE, Controls the policy that rounds top-level window corners
         _DWMWA_WINDOW_CORNER_PREFERENCE = 33,
 
+        // [set] Set window border color [since Windows 11 Build 22000]
+        _DWMWA_BORDER_COLOR = 34,
+
         // [get] UINT, width of the visible border around a thick frame window
         _DWMWA_VISIBLE_FRAME_BORDER_THICKNESS = 37,
 

--- a/src/core/windowagentbase.cpp
+++ b/src/core/windowagentbase.cpp
@@ -109,6 +109,8 @@ namespace QWK {
                    this attribute is only available on Windows 11.
             \li \c mica-alt: Specify a boolean value to enable or disable mica-alt material,
                    this attribute is only available on Windows 11.
+            \li \c dwm-border-color: Specifies the color of the window border,
+                   this attribute is only available on Windows 11.
             \li \c extra-margins: Specify a margin value to change the \c dwm extended area
                    geometry, you shouldn't change this attribute because it may break the
                    internal state.


### PR DESCRIPTION
New attribute "dwm-border-color" allows setting the window border color on Windows 11 using the 
DWMWA_BORDER_COLOR attribute.