### PR TITLE
Fix a pointer to NSWindowProxy that is no longer valid

### DIFF
--- a/src/core/contexts/cocoawindowcontext.mm
+++ b/src/core/contexts/cocoawindowcontext.mm
@@ -5,6 +5,8 @@
 #include "cocoawindowcontext_p.h"
 
 #include <algorithm>
+#include <atomic>
+#include <memory>
 
 #include <objc/runtime.h>
 #include <AppKit/AppKit.h>
@@ -176,6 +178,8 @@ namespace QWK {
         }
 
         ~NSWindowProxy() override {
+            lifetimeToken->store(false, std::memory_order_release);
+            
             [buttonObserver release];
 
             [nsview removeObserver:observer forKeyPath:@"window"];
@@ -588,7 +592,12 @@ namespace QWK {
                                    // become fullscreen.
 
             NSWindowProxy *self_ = this;
+            const auto lifetimeToken_ = lifetimeToken;
             dispatch_async(dispatch_get_main_queue(), ^{
+                if (!lifetimeToken_->load(std::memory_order_acquire)) {
+                    return;
+                }
+                
                 NSMutableArray<NSButton *> *array = [NSMutableArray arrayWithCapacity:3];
                 for (NSButton *button : self_->systemButtons()) {
                     button.hidden = !self_->systemButtonVisible;
@@ -739,7 +748,9 @@ namespace QWK {
         NSView *nsview = nil;
         QWK_NSViewObserver* observer = nil;
         QWK_NSButtonObserver* buttonObserver = nil;
-
+        
+        std::shared_ptr<std::atomic_bool> lifetimeToken = std::make_shared<std::atomic_bool>(true);
+        
         bool systemButtonVisible = true;
         bool checkButton = true;
         ScreenRectCallback screenRectCallback;


### PR DESCRIPTION
问题：在 `NSWindowProxy` 被 `delete` 后已经调用的 `dispatch_async` 仍然会执行。

修复异步执行 `dispatch_async` 时如果 `NSWindowProxy` 已经被 `delete` 可能会导致程序崩溃，通过 `std::shared_ptr<std::atomic_bool> lifetimeToken` 在析构时设置成 `false` 解决该问题。
