### PR TITLE
fix(example): preserve the custom title bar on Linux

### DIFF
--- a/examples/mainwindow/main.cpp
+++ b/examples/mainwindow/main.cpp
@@ -27,6 +27,14 @@ int main(int argc, char *argv[]) {
     QCoreApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
     QApplication a(argc, argv);
 
+#ifdef Q_OS_LINUX
+    // KDE Breeze calls QMainWindow::menuBar() while polishing the window. When a custom title bar
+    // is installed through QMainWindow::setMenuWidget(), that call replaces it with an empty
+    // QMenuBar and schedules the custom widget for deletion. Use Fusion on Linux so the WindowBar
+    // remains installed and visible without changing the native styles on other platforms.
+    QApplication::setStyle(QStringLiteral("Fusion"));
+#endif
+
     MainWindow w;
     w.show();
 


### PR DESCRIPTION
KDE Breeze calls QMainWindow::menuBar() while polishing a QMainWindow. This replaces the custom menu widget with an empty QMenuBar and schedules WindowBar for deletion.

Use the built-in Fusion style on Linux to avoid the Breeze code path while preserving native styles on other platforms.

Fix: #204

Before: 


<img  alt="qwk-mainwindow-before" src="https://github.com/user-attachments/assets/1539f7d7-5989-4629-a76e-80966c3eb534" />

After: 


<img alt="qwk-mainwindow-after" src="https://github.com/user-attachments/assets/5a4de4f6-08f8-42e9-a2da-d80a126c5a08" />

