### PR TITLE
Fix configure error regarding find_package which cannot find qmsetup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,11 +124,11 @@ if(NOT TARGET qmsetup::library)
         RESULT_PATH _package_path
     )
 
-    # Find package again
-    find_package(qmsetup REQUIRED PATHS ${_package_path})
-
     # Update import path
     set(qmsetup_DIR ${_package_path} CACHE PATH "" FORCE)
+
+    # Find package again
+    find_package(qmsetup REQUIRED PATHS ${_package_path})
 endif()
 
 qm_import(Filesystem)


### PR DESCRIPTION
When using a mxe toolchain, the following error appears:

```
CMake Error at build/win64/_deps/windowkit-src/CMakeLists.txt:133 (find_package):
  Could not find a package configuration file provided by "qmsetup" with any
  of the following names:

    qmsetupConfig.cmake
    qmsetup-config.cmake

  Add the installation prefix of "qmsetup" to CMAKE_PREFIX_PATH or set
  "qmsetup_DIR" to a directory containing one of the above files.  If
  "qmsetup" provides a separate development package or SDK, be sure it has
  been installed.
```

This fix simply sets the qmsetup_DIR variable before the call to find_package.

Related to #195