### PR TITLE
Fix:pinning-induced window position drift on Windows

### DIFF
--- a/examples/mainwindow/mainwindow.cpp
+++ b/examples/mainwindow/mainwindow.cpp
@@ -26,7 +26,7 @@
 
 #include <QWKWidgets/widgetwindowagent.h>
 
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
 #  include <QtCore/qt_windows.h>
 #endif
 

--- a/examples/mainwindow/mainwindow.cpp
+++ b/examples/mainwindow/mainwindow.cpp
@@ -26,6 +26,10 @@
 
 #include <QWKWidgets/widgetwindowagent.h>
 
+#ifdef Q_OS_WINDOWS
+#  include <QtCore/qt_windows.h>
+#endif
+
 #include <widgetframe/windowbar.h>
 #include <widgetframe/windowbutton.h>
 
@@ -127,6 +131,14 @@ bool MainWindow::event(QEvent *event) {
             }
             break;
         }
+
+#ifdef Q_OS_WINDOWS
+        case QEvent::WinIdChange:
+            if (!applyingStayOnTop) {
+                setStayOnTop(stayOnTop);
+            }
+            break;
+#endif
 
         default:
             break;
@@ -432,11 +444,14 @@ void MainWindow::installWindowAgent() {
 #ifndef Q_OS_MAC
     connect(windowBar, &QWK::WindowBar::pinRequested, this, [this, pinButton](bool pin) {
         if (isHidden() || isMinimized() || isMaximized() || isFullScreen()) {
+            pinButton->setChecked(stayOnTop);
             return;
         }
-        setWindowFlag(Qt::WindowStaysOnTopHint, pin);
-        show();
-        pinButton->setChecked(pin);
+        if (setStayOnTop(pin)) {
+            pinButton->setChecked(pin);
+        } else {
+            pinButton->setChecked(stayOnTop);
+        }
     });
     connect(windowBar, &QWK::WindowBar::minimizeRequested, this, &QWidget::showMinimized);
     connect(windowBar, &QWK::WindowBar::maximizeRequested, this, [this, maxButton](bool max) {
@@ -452,6 +467,46 @@ void MainWindow::installWindowAgent() {
         emulateLeaveEvent(maxButton);
     });
     connect(windowBar, &QWK::WindowBar::closeRequested, this, &QWidget::close);
+#endif
+}
+
+bool MainWindow::setStayOnTop(bool enabled) {
+#ifdef Q_OS_WINDOWS
+    if (applyingStayOnTop) {
+        return false;
+    }
+
+    const auto hwnd = reinterpret_cast<HWND>(internalWinId());
+    if (!hwnd) {
+        return false;
+    }
+
+    applyingStayOnTop = true;
+    const bool success = ::SetWindowPos(hwnd, enabled ? HWND_TOPMOST : HWND_NOTOPMOST,
+                                        0, 0, 0, 0,
+                                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
+                                            SWP_NOOWNERZORDER) != FALSE;
+    applyingStayOnTop = false;
+    if (success) {
+        stayOnTop = enabled;
+    }
+    return success;
+#else
+    if (windowFlags().testFlag(Qt::WindowStaysOnTopHint) == enabled) {
+        stayOnTop = enabled;
+        return true;
+    }
+
+    const bool visible = isVisible();
+    const QPoint frameTopLeft = frameGeometry().topLeft();
+    setWindowFlag(Qt::WindowStaysOnTopHint, enabled);
+    if (visible) {
+        show();
+        const QPoint clientOffset = geometry().topLeft() - frameGeometry().topLeft();
+        move(frameTopLeft + clientOffset);
+    }
+    stayOnTop = enabled;
+    return true;
 #endif
 }
 

--- a/examples/mainwindow/mainwindow.h
+++ b/examples/mainwindow/mainwindow.h
@@ -33,8 +33,11 @@ protected:
 private:
     void installWindowAgent();
     void loadStyleSheet(Theme theme);
+    bool setStayOnTop(bool stayOnTop);
 
     Theme currentTheme{};
+    bool stayOnTop{false};
+    bool applyingStayOnTop{false};
 
     QWK::WidgetWindowAgent *windowAgent;
 };


### PR DESCRIPTION
# Fix pinning-induced window position drift on Windows

## Summary

Fix the Widgets MainWindow example moving downward when the Pin button is toggled repeatedly on Windows.

The Pin action now changes only the native window z-order instead of changing `Qt::WindowStaysOnTopHint` and showing the window again. The selected Pin state is cached and restored if Qt recreates the native window handle.

## Problem

The previous Pin callback used:

```cpp
setWindowFlag(Qt::WindowStaysOnTopHint, pin);
show();
```

Changing a top-level window flag can recreate its native `HWND`. For a frameless window with custom non-client handling, recreating and showing the window can alter the conversion between client and frame coordinates. Repeated Pin/Unpin operations therefore caused the window to drift downward by approximately one title-bar height per toggle.

## Changes

- Use `SetWindowPos()` with `HWND_TOPMOST` or `HWND_NOTOPMOST` on Windows.
- Pass `SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER` so the operation changes only z-order.
- Use `internalWinId()` to avoid creating a native handle as a side effect.
- Cache the current stay-on-top state in the example window.
- Reapply the cached state after `QEvent::WinIdChange` so pinning survives unrelated native handle recreation.
- Guard against reentrant state application while handling native window changes.
- Restore the Pin button's checked state when the request cannot be applied, including requests made while the window is hidden, minimized, maximized, or full screen.
- Keep a geometry-preserving Qt fallback for non-Windows platforms.

This change is limited to the Widgets example and does not modify QWindowKit's public API.

## Verification

- [x] Built `QWKExample_MainWindow` in Release mode with Qt 6.8.3 and MSVC.
- [x] On Windows, toggle Pin/Unpin  and confirm the frame position and size do not change.
- [x] Confirm the window becomes topmost when pinned and returns to non-topmost when unpinned
- [x] Confirm the Pin button remains synchronized with the applied native state.
- [x] Confirm pinning is restored after native handle recreation.
- [x] Confirm minimize, maximize, restore, close, title-bar hit testing, and menu activation styling still work.

## Scope

No core WindowAgent behavior or public API is changed. The fix only replaces the example application's Pin policy implementation.