### PR TITLE
cocoawindowcontext: Skip unavailable system buttons (fixes crash)

### DIFF
--- a/src/core/contexts/cocoawindowcontext.mm
+++ b/src/core/contexts/cocoawindowcontext.mm
@@ -601,6 +601,9 @@ namespace QWK {
                 
                 NSMutableArray<NSButton *> *array = [NSMutableArray arrayWithCapacity:3];
                 for (NSButton *button : self_->systemButtons()) {
+                    if (!button) {
+                        continue;
+                    }
                     button.hidden = !self_->systemButtonVisible;
                     [array addObject:button];
                 }


### PR DESCRIPTION
## Summary

- Skip unavailable macOS standard window buttons when constructing the observer list.
- Prevent an Objective-C exception when a tool or modal window does not provide all three traffic-light buttons.

`-[NSMutableArray addObject:]` does not accept `nil`, while `standardWindowButton:` may return `nil` for buttons omitted by a particular window style.

## Testing

Configured and built QWindowKit on macOS with:

- `QWINDOWKIT_BUILD_QUICK=ON`
- `QWINDOWKIT_BUILD_WIDGETS=OFF`
- `QWINDOWKIT_BUILD_EXAMPLES=OFF`

Both `QWKCore` and `QWKQuick` built successfully.