### PR TITLE
修复 Win32 原生窗口重建后的 frame 位置漂移

### DIFF
--- a/src/core/contexts/win32windowcontext.cpp
+++ b/src/core/contexts/win32windowcontext.cpp
@@ -4,6 +4,7 @@
 
 #include "win32windowcontext_p.h"
 
+#include <cstdlib>
 #include <optional>
 
 #include <QtCore/QAbstractEventDispatcher>
@@ -71,6 +72,20 @@ namespace QWK {
 
     // Original Qt window proc function
     static WNDPROC g_qtWindowProc = nullptr;
+
+    static bool isLikelyFrameDriftAfterWinIdChange(HWND hwnd, const RECT &expectedFrameRect,
+                                                   const RECT &candidateFrameRect) {
+        const int dx = candidateFrameRect.left - expectedFrameRect.left;
+        const int dy = candidateFrameRect.top - expectedFrameRect.top;
+        const int dw = RECT_WIDTH(candidateFrameRect) - RECT_WIDTH(expectedFrameRect);
+        const int dh = RECT_HEIGHT(candidateFrameRect) - RECT_HEIGHT(expectedFrameRect);
+        const int expectedDrift =
+            int(getTitleBarHeight(hwnd)) +
+            (isWin11OrGreater() ? int(getWindowFrameBorderThickness(hwnd)) : 0);
+
+        return std::abs(dx) <= 1 && std::abs(dw) <= 2 && std::abs(dh) <= 2 && dy > 0 &&
+               std::abs(dy - expectedDrift) <= 2;
+    }
 
     static inline bool
 #if !QWINDOWKIT_CONFIG(ENABLE_WINDOWS_SYSTEM_BORDERS)
@@ -879,9 +894,21 @@ namespace QWK {
 
         // If the original window id is valid, remove all resources related
         if (oldWinId) {
-            removeManagedWindow(reinterpret_cast<HWND>(oldWinId));
+            const auto oldHWnd = reinterpret_cast<HWND>(oldWinId);
+            if (!restoringFrameRectAfterWinIdChange && isValidWindow(oldHWnd, false, true) &&
+                isWindowNoState(oldHWnd)) {
+                hasFrameRectBeforeWinIdChange =
+                    ::GetWindowRect(oldHWnd, &frameRectBeforeWinIdChange) != FALSE;
+            }
+            removeManagedWindow(oldHWnd);
         }
         if (!winId) {
+            QTimer::singleShot(0, this, [this]() {
+                if (!m_windowId) {
+                    hasFrameRectBeforeWinIdChange = false;
+                    hasPendingFrameRectAfterWinIdChange = false;
+                }
+            });
             return;
         }
 
@@ -910,6 +937,43 @@ namespace QWK {
 
         // Add managed window
         addManagedWindow(m_windowHandle, hWnd, this);
+
+        if (hasFrameRectBeforeWinIdChange && !restoringFrameRectAfterWinIdChange) {
+            pendingFrameRectAfterWinIdChange = frameRectBeforeWinIdChange;
+            hasPendingFrameRectAfterWinIdChange = true;
+            const RECT expectedFrameRect = pendingFrameRectAfterWinIdChange;
+            hasFrameRectBeforeWinIdChange = false;
+
+            QTimer::singleShot(0, this, [this, winId, expectedFrameRect]() {
+                if (m_windowId != winId || !m_windowHandle) {
+                    return;
+                }
+
+                const auto hWnd = reinterpret_cast<HWND>(m_windowId);
+                if (!isValidWindow(hWnd, false, true) || !isWindowNoState(hWnd)) {
+                    hasPendingFrameRectAfterWinIdChange = false;
+                    return;
+                }
+
+                RECT currentFrameRect{};
+                if (!::GetWindowRect(hWnd, &currentFrameRect)) {
+                    hasPendingFrameRectAfterWinIdChange = false;
+                    return;
+                }
+
+                if (!isLikelyFrameDriftAfterWinIdChange(hWnd, expectedFrameRect,
+                                                        currentFrameRect)) {
+                    hasPendingFrameRectAfterWinIdChange = false;
+                    return;
+                }
+
+                restoringFrameRectAfterWinIdChange = true;
+                ::SetWindowPos(hWnd, nullptr, expectedFrameRect.left, expectedFrameRect.top, 0, 0,
+                               SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER);
+                restoringFrameRectAfterWinIdChange = false;
+                hasPendingFrameRectAfterWinIdChange = false;
+            });
+        }
     }
 
     bool Win32WindowContext::windowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam,
@@ -935,6 +999,36 @@ namespace QWK {
 
         if (!isValidWindow(hWnd, false, true)) {
             return false;
+        }
+
+        if (message == WM_WINDOWPOSCHANGING && hasPendingFrameRectAfterWinIdChange &&
+            !restoringFrameRectAfterWinIdChange) {
+            auto pos = reinterpret_cast<WINDOWPOS *>(lParam);
+            if (pos && !(pos->flags & SWP_NOMOVE)) {
+                RECT candidateFrameRect{};
+                candidateFrameRect.left = pos->x;
+                candidateFrameRect.top = pos->y;
+                if (pos->flags & SWP_NOSIZE) {
+                    RECT currentFrameRect{};
+                    if (::GetWindowRect(hWnd, &currentFrameRect)) {
+                        candidateFrameRect.right =
+                            candidateFrameRect.left + RECT_WIDTH(currentFrameRect);
+                        candidateFrameRect.bottom =
+                            candidateFrameRect.top + RECT_HEIGHT(currentFrameRect);
+                    }
+                } else {
+                    candidateFrameRect.right = candidateFrameRect.left + pos->cx;
+                    candidateFrameRect.bottom = candidateFrameRect.top + pos->cy;
+                }
+
+                if (candidateFrameRect.right > candidateFrameRect.left &&
+                    candidateFrameRect.bottom > candidateFrameRect.top &&
+                    isLikelyFrameDriftAfterWinIdChange(hWnd, pendingFrameRectAfterWinIdChange,
+                                                       candidateFrameRect)) {
+                    pos->x = pendingFrameRectAfterWinIdChange.left;
+                    pos->y = pendingFrameRectAfterWinIdChange.top;
+                }
+            }
         }
 
         // Test snap layout

--- a/src/core/contexts/win32windowcontext_p.h
+++ b/src/core/contexts/win32windowcontext_p.h
@@ -79,6 +79,15 @@ namespace QWK {
 
         // Attributes
         bool noSystemMenu = false;
+
+        // Native HWNDs can be recreated while the logical QWindow stays alive. Keep the last
+        // stable native frame rect so we can prevent Qt's recreate path from applying a stale
+        // client-to-frame offset.
+        RECT frameRectBeforeWinIdChange{};
+        bool hasFrameRectBeforeWinIdChange = false;
+        RECT pendingFrameRectAfterWinIdChange{};
+        bool hasPendingFrameRectAfterWinIdChange = false;
+        bool restoringFrameRectAfterWinIdChange = false;
     };
 
 }


### PR DESCRIPTION
## 概要

修复 QWindowKit 托管窗口在 Windows 上发生原生 `HWND` 重建后，窗口 frame 可能向下漂移的问题。

当 Qt 重新创建顶层窗口的 native window 时，QWindowKit 的 Win32 hook 需要重新绑定到新的 `HWND`。在旧 `HWND` 失效、新 `HWND` 完整接管之间，Qt/Windows 可能先按系统标题栏参与一次 frame/client 坐标换算。随后 Qt 会把这个带系统标题栏偏移的 client geometry 当作新的窗口位置继续应用，导致窗口整体向下偏移约一个标题栏高度。

本 PR 在 QWK Win32 层缓存 native window 重建前的稳定 frame rect，并在 `WM_WINDOWPOSCHANGING` 阶段识别和修正这类漂移，避免错误位置真正应用到窗口。

## 问题

一个典型触发路径是示例程序中切换置顶状态：

```cpp
setWindowFlag(Qt::WindowStaysOnTopHint, pin);
show();